### PR TITLE
Remove global request context functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,25 +238,27 @@ As suggested in the code snippet above, you can also pass some additional parame
 
 ### Request Context
 
-In the event that you would like to set a request context on your requests to LexasCMS (i.e. for content personalisation), you can set a global request context by using the `vsf-lexascms` modules `setRequestContext` method.
+In the event that you would like to set a request context on your requests to LexasCMS (i.e. for content personalisation), you can provide a request context by passing the `context` property to the `search` function.
 
-You can call this method from anywhere, and doing so will automatically attach the provided context to all subsequent requests made to LexasCMS.
-
-**Note:** You can also retrieve the current request context using the `vsf-lexascms` modules `getRequestContext` method.
-
-The following snippet shows an example of setting the global request context:
+The following snippet shows an example of setting the request context:
 
 ```ts
-import { getRequestContext, setRequestContext } from 'vsf-lexascms';
+import { useContent } from 'vsf-lexascms';
 
-setRequestContext({
-  audienceAttributes: {
-    age: 25,
-    location: 'GB'
+const { search, content } = useContent();
+
+await search({
+  type: 'collection',
+  contentType: 'blogPost',
+  context: {
+    audienceAttributes: {
+      age: 25,
+      location: 'GB'
+    }
   }
 });
 
-console.log(getRequestContext()); // Logs the current global request context
+console.log(content); // Logs personalised blog posts for the provided request context
 ```
 
 Full Example

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ As suggested in the code snippet above, you can also pass some additional parame
 
 ### Request Context
 
-In the event that you would like to set a request context on your requests to LexasCMS (i.e. for content personalisation), you can provide a request context by passing the `context` property to the `search` function.
+In the event that you would like to set a request context on your requests to LexasCMS (i.e. for content personalisation), you can pass the `context` property to the `search` function.
 
 The following snippet shows an example of setting the request context:
 

--- a/src/composables/useContent/index.test.ts
+++ b/src/composables/useContent/index.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import base64 from 'base-64';
 import Vue from 'vue';
 
-import { setRequestContext, setup, useContent } from '../../index';
+import { setup, useContent } from '../../index';
 
 describe('useContent', () => {
 
@@ -14,11 +14,6 @@ describe('useContent', () => {
     setup({ spaceId: 'space-id' });
     // Setup Vue
     Vue.use(CompositionApi);
-  });
-
-  afterEach(() => {
-    // Reset global request context
-    setRequestContext(null);
   });
 
   test('search should request a single item', async () => {
@@ -75,39 +70,9 @@ describe('useContent', () => {
     }));
   });
 
-  test('search should use global request context', async () => {
+  test('search should set request context if provided', async () => {
     // Mock Axios call
     axiosGetSpy.mockResolvedValueOnce(true);
-    // Define global request context
-    const globalRequestContext = {
-      audienceAttributes: { location: 'GB' }
-    };
-    // Set global request context
-    setRequestContext(globalRequestContext);
-    // Get search method
-    const { search } = useContent('content-ref-id');
-    // Call search method
-    await search({
-      type: 'collection',
-      contentType: 'content-type'
-    });
-    // Assert
-    expect(axiosGetSpy).toHaveBeenCalledWith('/content-type', expect.objectContaining({
-      baseURL: `https://space-id.spaces.lexascms.com/delivery/jsonapi`,
-      headers: {
-        'Content-Type': 'application/vnd.api+json',
-        'x-lexascms-context': base64.encode(JSON.stringify(globalRequestContext))
-      }
-    }));
-  });
-
-  test('search should prefer provided context over global request context', async () => {
-    // Mock Axios call
-    axiosGetSpy.mockResolvedValueOnce(true);
-    // Set global request context
-    setRequestContext({
-      audienceAttributes: { location: 'GB' }
-    });
     // Get search method
     const { search } = useContent('content-ref-id');
     // Call search method

--- a/src/composables/useContent/index.ts
+++ b/src/composables/useContent/index.ts
@@ -5,7 +5,7 @@ import Jsona from 'jsona';
 import * as qs from 'qs';
 
 import { LexascmsContent, LexascmsContextSearchParams } from '../../types/lexascms/index';
-import { getConfig, getRequestContext } from '../../index';
+import { getConfig } from '../../index';
 
 export const useContent = useContentFactory<LexascmsContent, LexascmsContextSearchParams>({
   
@@ -28,12 +28,10 @@ export const useContent = useContentFactory<LexascmsContent, LexascmsContextSear
       params: args.params,
       paramsSerializer: /* istanbul ignore next */ (params: any) => qs.stringify(params)
     };
-    // Get request context
-    const requestContext = args.context !== undefined ? args.context : getRequestContext();
     // Add LexasCMS Request Context if required
-    if (requestContext !== null) {
+    if (args.context !== undefined) {
       requestOptions.headers['x-lexascms-context'] = base64.encode(
-        JSON.stringify(requestContext)
+        JSON.stringify(args.context)
       );
     }
     // Send request

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,5 @@
 import {
   getConfig,
-  getRequestContext,
-  setRequestContext,
   setup
 } from './index';
 
@@ -14,19 +12,6 @@ describe('vsf-lexascms', () => {
     setup({ spaceId: 'space-id' });
     // Assert that config is as expected
     expect(getConfig()).toEqual({ spaceId: 'space-id' });
-  });
-
-  test('setRequestContext should update global request context', async () => {
-    // Assert that request context is at default value
-    expect(getRequestContext()).toEqual(null);
-    // Setup module
-    setRequestContext({
-      audienceAttributes: { location: 'GB' }
-    });
-    // Assert that request context is as expected
-    expect(getRequestContext()).toEqual({
-      audienceAttributes: { location: 'GB' }
-    });
   });
 
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,13 @@
 import { useContent } from './composables/useContent';
-import { LexascmsSetupConfig, LexascmsRequestContext } from './types/lexascms';
+import { LexascmsSetupConfig } from './types/lexascms';
 
 let _config: LexascmsSetupConfig = {
   spaceId: null
 };
 
-let _requestContext: LexascmsRequestContext | null = null;
-
 const getConfig = (): LexascmsSetupConfig => {
   return _config;
 };
-
-const getRequestContext = (): LexascmsRequestContext | null => {
-  return _requestContext;
-}
-
-const setRequestContext = (requestContext: LexascmsRequestContext | null): void => {
-  _requestContext = requestContext;
-}
 
 const setup = (config: LexascmsSetupConfig) => {
   _config = config;
@@ -25,8 +15,6 @@ const setup = (config: LexascmsSetupConfig) => {
 
 export {
   getConfig,
-  getRequestContext,
-  setRequestContext,
   setup,
   useContent
 };


### PR DESCRIPTION
This doesn't currently work as expected when used with SSR and will be re-introduced in a future release.